### PR TITLE
Improved error handling for OT-node StdErr output

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, The OTNS Authors.
+// Copyright (c) 2020-2023, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -266,15 +266,17 @@ func (rt *CmdRunner) executeGo(cc *CommandContext, cmd *GoCmd) {
 			done = sim.GoAtSpeed(timeDurToGo, speed)
 		})
 		<-done // block for the simulation period.
+		cc.err = rt.sim.Error()
 	} else {
-		for { // run forever
+		for { // run forever or until rt.ctx indicates "done"
 			rt.postAsyncWait(func(sim *simulation.Simulation) {
 				sim.SetSpeed(speed) // permanent speed update
 				done = sim.Go(time.Hour)
 			})
 			<-done
 
-			if rt.ctx.Err() != nil {
+			if rt.ctx.Err() != nil || rt.sim.Error() != nil {
+				cc.err = rt.sim.Error()
 				break
 			}
 		}


### PR DESCRIPTION
Node error will be treated as a failure of the last 'go' command. E.g. for CI or GUI-less simulation, such errors cannot be silently ignored so this is fixed by this feature.