### PR TITLE
Feature: 'exe' command to set default OT executable per node-type, and be able to change it.

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,6 +13,7 @@ Python libraries use the CLI to manage simulations.
 * [cv](#cv-option-onoff-)
 * [del](#del-node-id-node-id-)
 * [energy](#energy-save--filename-)
+* [exe](#exe)
 * [exit](#exit)
 * [go](#go-duration-speed-particular-speed)
 * [help](#help)
@@ -34,8 +35,6 @@ Python libraries use the CLI to manage simulations.
 * [title](#title-string)
 * [unwatch](#unwatch-node-id-node-id-)
 * [watch](#watch-node-id-node-id-)
-   * [watch \<nodeid\> \<LogLevel\>](#watch-node-id-node-id--loglevel)
-   * [watch default \<LogLevel\>](#watch-default-loglevel)
 * [web](#web)
 
 ## OTNS command reference
@@ -164,6 +163,59 @@ Done
 > exit
 Done
 <EOF>
+```
+
+### exe
+
+Use 'exe' without arguments to list the OpenThread (OT) executables, or shell scripts, that are preconfigured for each 
+of the node types
+FTD (Full Thread Device), MTD (Minimal Thread Device) and BR (Thread Border Router). When a new node is created the
+executable currently in this list is used to start a node instance of the respective node type.
+
+```bash
+> exe
+ftd: ./ot-cli-ftd
+mtd: ./ot-cli-ftd
+br : ./otbr-sim.sh
+Done
+>  
+```
+
+### exe default
+
+Set all OpenThread (OT) executables, or shell scripts, for all node types back to the default values that OT-NS uses.
+
+```bash
+> exe default
+ftd: ./ot-cli-ftd
+mtd: ./ot-cli-ftd
+br : ./otbr-sim.sh
+Done
+>
+```
+
+### exe \( ftd | mtd | br \) "\<path-to-executable\>"
+
+Change the OpenThread (OT) executable, or shell script, for a particular node types as provided in the first 
+argument (ftd, mtd, or br). The path-to-executable is provided in the second argument and will replace the current 
+default executable for that node type.
+
+Note that the default executable is used when normally adding a node using the GUI or a command such as 
+```add router x 200 y 200``` where the executable is not explictly specified. The "exe" argument of the "add" command 
+will however override the default executable always, for example as in the command 
+```add router x 200 y 200 exe "./my-ot-cli-ftd"``` .
+
+```bash
+> exe ftd "./my-ot-cli-ftd"
+Done
+> exe br "./br-script.sh"
+Done
+> exe
+ftd: ./my-ot-cli-ftd
+mtd: ./ot-cli-ftd
+br : ./br-script.sh
+Done
+>
 ```
 
 ### go \<duration\> \[speed \<particular-speed\>\]

--- a/cli/ast.go
+++ b/cli/ast.go
@@ -44,6 +44,8 @@ type Command struct {
 	Debug               *DebugCmd               `| @@` //nolint
 	Del                 *DelCmd                 `| @@` //nolint
 	DemoLegend          *DemoLegendCmd          `| @@` //nolint
+	Energy              *EnergyCmd              `| @@` //nolint
+	Exe                 *ExeCmd                 `| @@` //nolint
 	Exit                *ExitCmd                `| @@` //nolint
 	Go                  *GoCmd                  `| @@` //nolint
 	Help                *HelpCmd                `| @@` //nolint
@@ -66,7 +68,6 @@ type Command struct {
 	Unwatch             *UnwatchCmd             `| @@` //nolint
 	Watch               *WatchCmd               `| @@` //nolint
 	Web                 *WebCmd                 `| @@` //nolint
-	Energy              *EnergyCmd              `| @@` //nolint
 }
 
 // noinspection GoStructTag
@@ -349,6 +350,13 @@ type EnergyCmd struct {
 // noinspection GoStructTag
 type SaveFlag struct {
 	Dummy struct{} `"save"` //nolint
+}
+
+// noinspection GoStructTag
+type ExeCmd struct {
+	Cmd      struct{} `"exe"`                             //nolint
+	NodeType string   `[ @("ftd"|"mtd"|"br"|"default") ]` //nolint
+	Path     string   `[ @String ]`                       //nolint
 }
 
 // noinspection GoStructTag

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, The OTNS Authors.
+// Copyright (c) 2020-2023, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -66,6 +66,12 @@ func TestParseBytes(t *testing.T) {
 	assert.True(t, ParseBytes([]byte("del"), &cmd) != nil)
 
 	assert.True(t, ParseBytes([]byte("demo_legend \"title\" 100 200"), &cmd) == nil && cmd.DemoLegend != nil)
+
+	assert.True(t, ParseBytes([]byte("exe mtd \"MyExecutable_thingy\""), &cmd) == nil && cmd.Exe != nil)
+	assert.True(t, ParseBytes([]byte("exe ftd \"./path/to/my/ot-cli-ftd\""), &cmd) == nil && cmd.Exe != nil)
+	assert.True(t, ParseBytes([]byte("exe br \"./path/to/my/br-script.sh\""), &cmd) == nil && cmd.Exe != nil)
+	assert.True(t, ParseBytes([]byte("exe"), &cmd) == nil && cmd.Exe != nil)
+	assert.True(t, ParseBytes([]byte("exe default"), &cmd) == nil && cmd.Exe != nil)
 
 	assert.True(t, ParseBytes([]byte("exit"), &cmd) == nil && cmd.Exit != nil)
 

--- a/cli/help.go
+++ b/cli/help.go
@@ -51,6 +51,7 @@ var commandHelp = map[string]string{
 	"cv":         "Configure visualization options.",
 	"del":        "Delete node(s) by node ID.",
 	"energy":     "Save node energy use information to a file.",
+	"exe":        "Display or set the OT executables used per node type.",
 	"exit":       "Exit OTNS (if not in node context) or exit node context.",
 	"go":         "Simulate for a specified time.",
 	"joins":      "Connect finished joiner sessions.",

--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openthread/ot-ns/radiomodel"
 	"github.com/openthread/ot-ns/threadconst"
 	. "github.com/openthread/ot-ns/types"
+
 	"github.com/simonlingoogle/go-simplelogger"
 )
 
@@ -89,6 +90,12 @@ type Node struct {
 func newNode(d *Dispatcher, nodeid NodeId, cfg *NodeConfig) *Node {
 	simplelogger.AssertTrue(cfg.RadioRange >= 0)
 
+	radioCfg := &radiomodel.RadioNodeConfig{
+		X:          float64(cfg.X),
+		Y:          float64(cfg.Y),
+		RadioRange: float64(cfg.RadioRange),
+	}
+
 	nc := &Node{
 		D:             d,
 		Id:            nodeid,
@@ -101,7 +108,7 @@ func newNode(d *Dispatcher, nodeid NodeId, cfg *NodeConfig) *Node {
 		Role:          OtDeviceRoleDisabled,
 		conn:          nil, // connection will be set when first event is received from node.
 		err:           nil, // keep track of connection errors.
-		radioNode:     radiomodel.NewRadioNode(nodeid, cfg),
+		radioNode:     radiomodel.NewRadioNode(nodeid, radioCfg),
 		joinerState:   OtJoinerStateIdle,
 		watchLogLevel: WatchDefaultLevel,
 	}

--- a/otns_main/otns_main.go
+++ b/otns_main/otns_main.go
@@ -37,28 +37,18 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openthread/ot-ns/cli/runcli"
-
-	"github.com/openthread/ot-ns/threadconst"
-
-	"github.com/openthread/ot-ns/dispatcher"
-
-	webSite "github.com/openthread/ot-ns/web/site"
-
-	"github.com/openthread/ot-ns/web"
-
-	"github.com/pkg/errors"
-
-	"github.com/openthread/ot-ns/progctx"
-	"github.com/openthread/ot-ns/visualize"
-
-	visualizeGrpc "github.com/openthread/ot-ns/visualize/grpc"
-
-	visualizeMulti "github.com/openthread/ot-ns/visualize/multi"
-
 	"github.com/openthread/ot-ns/cli"
-
+	"github.com/openthread/ot-ns/cli/runcli"
+	"github.com/openthread/ot-ns/dispatcher"
+	"github.com/openthread/ot-ns/progctx"
 	"github.com/openthread/ot-ns/simulation"
+	"github.com/openthread/ot-ns/threadconst"
+	"github.com/openthread/ot-ns/visualize"
+	visualizeGrpc "github.com/openthread/ot-ns/visualize/grpc"
+	visualizeMulti "github.com/openthread/ot-ns/visualize/multi"
+	"github.com/openthread/ot-ns/web"
+	webSite "github.com/openthread/ot-ns/web/site"
+	"github.com/pkg/errors"
 	"github.com/simonlingoogle/go-simplelogger"
 )
 
@@ -90,10 +80,10 @@ func parseArgs() {
 	defaultOtCli := os.Getenv("OTNS_OT_CLI")
 	defaultOtCliMtd := os.Getenv("OTNS_OT_CLI_MTD")
 	if defaultOtCli == "" {
-		defaultOtCli = "./ot-cli-ftd"
+		defaultOtCli = simulation.DefaultExecutableConfig.Ftd
 	}
 	if defaultOtCliMtd == "" {
-		defaultOtCliMtd = defaultOtCli // use same binary for FTD/MTD by default.
+		defaultOtCliMtd = simulation.DefaultExecutableConfig.Mtd
 	}
 
 	flag.StringVar(&args.Speed, "speed", "1", "set simulating speed")
@@ -247,8 +237,9 @@ func createSimulation(ctx *progctx.ProgCtx) *simulation.Simulation {
 	var err error
 
 	simcfg := simulation.DefaultConfig()
-	simcfg.OtCliFtdPath = args.OtCliPath
-	simcfg.OtCliMtdPath = args.OtCliMtdPath
+	simcfg.ExeConfig.Ftd = args.OtCliPath
+	simcfg.ExeConfig.Mtd = args.OtCliMtdPath
+	simcfg.NewNodeConfig.InitScript = simulation.DefaultNodeInitScript
 
 	args.Speed = strings.ToLower(args.Speed)
 	if args.Speed == "max" {

--- a/otnstester/tests/consts.go
+++ b/otnstester/tests/consts.go
@@ -26,7 +26,9 @@
 
 package main
 
-import "github.com/openthread/ot-ns/types"
+import (
+	"github.com/openthread/ot-ns/types"
+)
 
 const (
 	RoleLeader = "leader"

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -306,7 +306,7 @@ class BasicTests(OTNSTestCase):
         self.assertNodeState(reed, 'child')
 
         ns.set_router_upgrade_threshold(reed, 2)
-        ns.go(121)
+        ns.go(130)
         self.assertNodeState(reed, 'router')
 
     def testSetRouterDowngradeThreshold(self):
@@ -396,6 +396,22 @@ class BasicTests(OTNSTestCase):
             ns.add('router', executable = 'ot-cli-nonexistent')
         ns.go(5)
         self.assertEqual(1, len(ns.nodes()))
+
+    def testExe(self):
+        ns: OTNS = self.ns
+        ns.add('router')
+        ns.go(10)
+        ns._do_command("exe ftd \"./path/to/non-existent-executable\"")
+        with self.assertRaises(errors.OTNSCliError):
+            ns.add('router')
+        ns._do_command("exe")
+        ns._do_command("exe default")
+        ns.go(10)
+        ns.add('router')
+        ns.go(10)
+        ns.add('fed')
+        ns.go(10)
+        self.assertTrue(len(ns.nodes()) == 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylibs/unittests/test_csl.py
+++ b/pylibs/unittests/test_csl.py
@@ -34,6 +34,10 @@ from otns.cli import errors, OTNS
 
 
 class CslTests(OTNSTestCase):
+    #override
+    def setUp(self):
+        super().setUp()
+        self.ns.radiomodel = 'MutualInterference'
 
     def verifyPings(self, pings, n, maxDelay=1000, maxFails=0):
         self.assertEqual(n, len(pings))

--- a/pylibs/unittests/test_radiomodels.py
+++ b/pylibs/unittests/test_radiomodels.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2022,-2023 The OTNS Authors.
+# Copyright (c) 2022-2023 The OTNS Authors.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/radiomodel/radionode.go
+++ b/radiomodel/radionode.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, The OTNS Authors.
+// Copyright (c) 2022-2023, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -60,14 +60,19 @@ type RadioNode struct {
 	rssiSampleMax DbmValue
 }
 
-func NewRadioNode(nodeid NodeId, cfg *NodeConfig) *RadioNode {
+type RadioNodeConfig struct {
+	X, Y       float64
+	RadioRange float64
+}
+
+func NewRadioNode(nodeid NodeId, cfg *RadioNodeConfig) *RadioNode {
 	rn := &RadioNode{
 		Id:            nodeid,
 		TxPower:       defaultTxPowerDbm,
 		RxSensitivity: receiveSensitivityDbm,
-		X:             float64(cfg.X),
-		Y:             float64(cfg.Y),
-		RadioRange:    float64(cfg.RadioRange),
+		X:             cfg.X,
+		Y:             cfg.Y,
+		RadioRange:    cfg.RadioRange,
 		RadioChannel:  uint8(DefaultChannelNumber),
 		rssiSampleMax: RssiMinusInfinity,
 	}

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -27,61 +27,31 @@
 package simulation
 
 import (
-	"fmt"
-
-	"github.com/openthread/ot-ns/threadconst"
 	. "github.com/openthread/ot-ns/types"
 )
 
-const (
-	DefaultNetworkName = "OTSIM"
-	DefaultNetworkKey  = "00112233445566778899aabbccddeeff"
-	DefaultPanid       = 0xface
-	DefaultChannel     = 11
-)
-
-// DefaultNodeInitScript is an array of commands, sent to a new node by default (unless changed).
-var DefaultNodeInitScript = []string{
-	"networkname " + DefaultNetworkName,
-	"networkkey " + DefaultNetworkKey,
-	fmt.Sprintf("panid 0x%x", DefaultPanid),
-	fmt.Sprintf("channel %d", DefaultChannel),
-	//"routerselectionjitter 1", // jitter can be set to '1' to speed up network formation for realtime tests.
-	"ifconfig up",
-	"thread start",
+type ExecutableConfig struct {
+	Ftd string
+	Mtd string
+	Br  string
 }
 
-type Config struct {
-	InitScript     []string
-	ExeConfig      ExecutableConfig
-	NewNodeConfig  NodeConfig
-	Speed          float64
-	ReadOnly       bool
-	RawMode        bool
-	Real           bool
-	AutoGo         bool
-	DispatcherHost string
-	DispatcherPort int
-	DumpPackets    bool
-	RadioModel     string
-	Id             int
-	Channel        ChannelId
+var DefaultExecutableConfig ExecutableConfig = ExecutableConfig{
+	Ftd: "./ot-cli-ftd",
+	Mtd: "./ot-cli-ftd",
+	Br:  "./otbr-sim.sh",
 }
 
-func DefaultConfig() *Config {
-	return &Config{
-		InitScript:     DefaultNodeInitScript,
-		ExeConfig:      DefaultExecutableConfig,
-		NewNodeConfig:  DefaultNodeConfig(),
-		Speed:          1,
-		ReadOnly:       false,
-		RawMode:        false,
-		Real:           false,
-		AutoGo:         true,
-		DispatcherHost: "localhost",
-		DispatcherPort: threadconst.InitialDispatcherPort,
-		RadioModel:     "Ideal_Rssi",
-		Id:             0,
-		Channel:        DefaultChannel,
+func DetermineExecutableBasedOnConfig(nodeCfg *NodeConfig, executableCfg *ExecutableConfig) string {
+	if nodeCfg.IsRouter {
+		return executableCfg.Ftd
 	}
+	if nodeCfg.IsMtd {
+		return executableCfg.Mtd
+	}
+	if nodeCfg.IsBorderRouter {
+		return executableCfg.Br
+	}
+	// FED or other type.
+	return executableCfg.Ftd
 }

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -95,10 +95,6 @@ func NewSimulation(ctx *progctx.ProgCtx, cfg *Config, dispatcherCfg *dispatcher.
 }
 
 func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
-	if cfg == nil {
-		cfg = DefaultNodeConfig()
-	}
-
 	nodeid := cfg.ID
 	if nodeid <= 0 {
 		nodeid = s.genNodeId()
@@ -106,6 +102,11 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 
 	if s.nodes[nodeid] != nil {
 		return nil, errors.Errorf("node %d already exists", nodeid)
+	}
+
+	// auto-selection of Executable by simulation's policy, in case not defined yet.
+	if len(cfg.ExecutablePath) == 0 {
+		cfg.ExecutablePath = DetermineExecutableBasedOnConfig(cfg, &s.cfg.ExeConfig)
 	}
 
 	// creation of the sim/dispatcher nodes
@@ -132,11 +133,7 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 		}
 		node.setupMode()
 		if !s.rawMode {
-			initScript := cfg.InitScript
-			if len(initScript) == 0 {
-				initScript = s.cfg.InitScript // use default, if indicated so in cfg.
-			}
-			node.SetupNetworkParameters(initScript)
+			node.RunInitScript(cfg.InitScript)
 			node.Start()
 		}
 	}
@@ -359,4 +356,8 @@ func (s *Simulation) SetNetworkInfo(networkInfo visualize.NetworkInfo) {
 
 func (s *Simulation) GetEnergyAnalyser() *energy.EnergyAnalyser {
 	return s.energyAnalyser
+}
+
+func (s *Simulation) GetConfig() *Config {
+	return s.cfg
 }

--- a/types/node_config.go
+++ b/types/node_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, The OTNS Authors.
+// Copyright (c) 2020-2023, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,12 @@
 
 package types
 
+const (
+	DefaultRadioRange = 160
+)
+
+// NodeConfig is a generic config for a new simulated node (used in dispatcher, simulation, radiomodel,
+// ... packages).
 type NodeConfig struct {
 	ID             int
 	X, Y           int
@@ -39,8 +45,8 @@ type NodeConfig struct {
 	InitScript     []string
 }
 
-func DefaultNodeConfig() *NodeConfig {
-	return &NodeConfig{
+func DefaultNodeConfig() NodeConfig {
+	return NodeConfig{
 		ID:             -1, // -1 for the next available nodeid
 		X:              0,
 		Y:              0,
@@ -48,9 +54,9 @@ func DefaultNodeConfig() *NodeConfig {
 		IsMtd:          false,
 		IsBorderRouter: false,
 		RxOffWhenIdle:  false,
-		RadioRange:     160,
-		ExecutablePath: "", // empty string means 'use simulation default'
+		RadioRange:     DefaultRadioRange,
+		ExecutablePath: "",
 		Restore:        false,
-		InitScript:     []string{}, // empty means 'use simulation default'
+		InitScript:     nil,
 	}
 }


### PR DESCRIPTION
Also some refactoring to streamline the configuration flow
* User or environment var configures FTD/MTD executables
* OT-NS sets this configuration in the Config of the created Simulation object.
* When new node is created, config is grabbed from Simulation object's Config.
* the Simulation.Config may be updated on the fly by the user (e.g. using the 'exe' command)