### PR TITLE
Fix: platform radio channel setting when MAC/subMAC switches channel

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -1489,8 +1489,8 @@ func (d *Dispatcher) handleRadioState(node *Node, evt *Event) {
 	energyState := evt.RadioStateData.EnergyState
 
 	const hdr = "(OTNS)       [T] RadioState----:"
-	node.logger.Tracef("%s EnergyState=%s SubState=%s RadioState=%s RadioTime=%d NextStTime=+%d",
-		hdr, energyState, subState, state, evt.RadioStateData.RadioTime, evt.Delay)
+	node.logger.Tracef("%s EnergyState=%s SubState=%s RadioState=%s Ch=%d RadioTime=%d NextStTime=+%d",
+		hdr, energyState, subState, state, evt.RadioStateData.Channel, evt.RadioStateData.RadioTime, evt.Delay)
 
 	if d.energyAnalyser != nil {
 		radioEnergy := d.energyAnalyser.GetNode(node.Id)

--- a/ot-rfsim/src/radio.c
+++ b/ot-rfsim/src/radio.c
@@ -1416,6 +1416,7 @@ void platformRadioProcess(otInstance *aInstance)
 
             case RFSIM_RADIO_SUBSTATE_TX_TX_TO_RX:
                 // no Ack was requested
+                sOngoingOperationChannel = sCurrentChannel;
                 setRadioSubState(RFSIM_RADIO_SUBSTATE_IFS_WAIT, ifsTime - sTurnaroundTimeUs);
                 break;
 
@@ -1435,11 +1436,13 @@ void platformRadioProcess(otInstance *aInstance)
             case RFSIM_RADIO_SUBSTATE_TX_ACK_RX_ONGOING:
                 // wait until Ack receive is done. In platformRadioRxDone() the next state is selected.
                 // if we get here on the timer, this ongoing Ack wasn't received properly.
+                sOngoingOperationChannel = sCurrentChannel;
                 setRadioSubState(RFSIM_RADIO_SUBSTATE_IFS_WAIT, ifsTime);
                 signalRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NO_ACK);
                 break;
 
             case RFSIM_RADIO_SUBSTATE_IFS_WAIT:
+                sOngoingOperationChannel = sCurrentChannel;
                 setRadioSubState(RFSIM_RADIO_SUBSTATE_READY, UNDEFINED_TIME_US);
                 sTxWait = false;
                 break;
@@ -1472,6 +1475,7 @@ void platformRadioProcess(otInstance *aInstance)
             case RFSIM_RADIO_SUBSTATE_RX_ENERGY_SCAN:
                 if (IsTimeAfterOrEqual(otPlatAlarmMilliGetNow(), sEnergyScanEndTime))
                 {
+                    sOngoingOperationChannel = sCurrentChannel;
                     otPlatRadioEnergyScanDone(aInstance, sEnergyScanResult);
                     setRadioSubState(RFSIM_RADIO_SUBSTATE_READY, UNDEFINED_TIME_US);
                     sEnergyScanning = false;

--- a/pylibs/unittests/test_commissioning.py
+++ b/pylibs/unittests/test_commissioning.py
@@ -55,6 +55,7 @@ class CommissioningTests(OTNSTestCase):
 
     def testRawSetup(self):
         ns = self.ns
+        ns.watch_default('trace') # for most detailed radio logs
         n1 = ns.add("router")
         n2 = ns.add("router")
         n3 = ns.add("router")
@@ -71,7 +72,7 @@ class CommissioningTests(OTNSTestCase):
             ns.ifconfig_up(id)
             ns.thread_start(id)
 
-        self.go(350)
+        self.go(50)
         self.assertFormPartitions(1)
 
     def testCommissioningOneHop(self):


### PR DESCRIPTION
[ot-rfsim] bugfix radio channel setting when MAC/subMAC switches to listen on a different channel.