### PR TITLE
Fix: do Git submodule update when doing 'bootstrap' after a code update

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -41,6 +41,9 @@ else
     exit 1
 fi
 
+# Get (first time) or update (after a 'git pull') all submodules.
+git submodule update --init
+
 # shellcheck source=script/utils.sh
 . "$(dirname "$0")"/utils.sh
 


### PR DESCRIPTION
[script] bootstrap now includes a 'git submodule update' to cover the case of updating OTNS2 with 'git pull'.