### PR TITLE
[ccm] Feature: autostart for CCM nodes using CCM-All onboarding

### DIFF
--- a/pylibs/case_studies/ccm.py
+++ b/pylibs/case_studies/ccm.py
@@ -43,9 +43,11 @@ global registrar_log_file
 
 thread_domain_name = "TestCcmDomain"
 
+
 def setupNs():
     logging.info("Setting up for Thread CCM sandbox")
-    ns = OTNS(otns_args=['-log', 'debug', '-pcap', 'wpan-tap', '-seed', '4', '-ot-script', './pylibs/case_studies/ccm.yaml'])
+    ns = OTNS(
+        otns_args=['-log', 'debug', '-pcap', 'wpan-tap', '-seed', '4', '-ot-script', './pylibs/case_studies/ccm.yaml'])
     ns.watch_default('debug')
     ns.web()
     ns.set_title('Thread CCM sandbox for IETF 121')
@@ -54,6 +56,7 @@ def setupNs():
     ns.coaps_enable()
     #ns.radiomodel = 'MIDisc'  # enforce strict line topologies for testing
     return ns
+
 
 def setActiveDataset(ns, n1) -> None:
     ns.node_cmd(n1, "dataset init new")
@@ -68,6 +71,7 @@ def setActiveDataset(ns, n1) -> None:
     ns.node_cmd(n1, "dataset securitypolicy 672 orcCR 3")  # enable CCM-commissioning flag in secpolicy
     ns.node_cmd(n1, "dataset commit active")
 
+
 def startRegistrar(ns):
     logging.debug("starting OT Registrar")
     ns.registrar_log_file = open("tmp/ot-registrar.log", 'w')
@@ -75,8 +79,9 @@ def startRegistrar(ns):
         'java', '-jar', './etc/ot-registrar/ot-registrar.jar', '-registrar', '-vvv', '-f',
         './etc/ot-registrar/credentials_registrar.p12', '-d', thread_domain_name
     ],
-                                             stdout=ns.registrar_log_file,
-                                             stderr=subprocess.STDOUT)
+                     stdout=ns.registrar_log_file,
+                     stderr=subprocess.STDOUT)
+
 
 def verifyRegistrarStarted():
     for n in range(1, 20):
@@ -89,6 +94,7 @@ def verifyRegistrarStarted():
                     if "ot-registrar.jar" in process_list:
                         return True
     return False
+
 
 def enrollBr(ns, nid):
     ns.coaps()  # clear coaps
@@ -103,6 +109,7 @@ def enrollBr(ns, nid):
     if len(coap_events) != 4:  # messages are /rv, /vs, /sen, /es
         logging.error("BR may not have enrolled correctly.")
         #raise Exception("BR may not have enrolled correctly.")
+
 
 def setupStartTopology(ns):
     n1 = ns.add("br", version="ccm")
@@ -128,6 +135,7 @@ def setupStartTopology(ns):
     ns.speed = 1
     ns.autogo = True
 
+
 def main():
     ns = setupNs()
     if not verifyRegistrarStarted():
@@ -137,6 +145,7 @@ def main():
             return
     setupStartTopology(ns)
     ns.interactive_cli()
+
 
 if __name__ == '__main__':
     try:

--- a/pylibs/case_studies/ccm.py
+++ b/pylibs/case_studies/ccm.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024, The OTNS Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Thread Commercial Commissioning Mode (CCM) tests using cBRSKI. Nodes can onboard into a Thread Domain
+# using a localhost server, OT-Registrar, which runs from a Java JAR file. The Registrar
+# communicates with a MASA server that creates the Voucher that the node needs to approve the
+# onboarding. The Registrar generates the final domain identity (LDevID certificate) for the Joiner to use.
+# See IETF ANIMA WG cBRSKI draft for details. https://datatracker.ietf.org/doc/draft-ietf-anima-constrained-voucher/
+
+import logging
+import os
+import time
+import subprocess
+
+from otns.cli import OTNS
+from otns.cli.errors import OTNSExitedError
+
+global registrar_log_file
+
+thread_domain_name = "TestCcmDomain"
+
+def setupNs():
+    logging.info("Setting up for Thread CCM sandbox")
+    ns = OTNS(otns_args=['-log', 'debug', '-pcap', 'wpan-tap', '-seed', '4', '-ot-script', './pylibs/case_studies/ccm.yaml'])
+    ns.watch_default('debug')
+    ns.web()
+    ns.set_title('Thread CCM sandbox for IETF 121')
+    # configure sim-host server that acts as BRSKI Registrar. TODO update IPv6 addr
+    ns.cmd('host add "masa.example.com" "910b::1234" 5684 5684')
+    ns.coaps_enable()
+    #ns.radiomodel = 'MIDisc'  # enforce strict line topologies for testing
+    return ns
+
+def setActiveDataset(ns, n1) -> None:
+    ns.node_cmd(n1, "dataset init new")
+    ns.node_cmd(n1, "dataset networkname CcmTestNet")
+    ns.node_cmd(n1, "dataset channel 22")
+    ns.node_cmd(n1, "dataset activetimestamp 456789")
+    ns.node_cmd(n1, "dataset panid 0x1234")
+    ns.node_cmd(n1, "dataset extpanid 39758ec8144b07fb")
+    ns.node_cmd(n1, "dataset pskc 3ca67c969efb0d0c74a4d8ee923b576c")
+    ns.node_cmd(n1, "dataset meshlocalprefix fd00:777e:10ca::")
+    ns.node_cmd(n1, "dataset networkkey 00112233445566778899aabbccddeeff")  # allow easy Wireshark dissecting
+    ns.node_cmd(n1, "dataset securitypolicy 672 orcCR 3")  # enable CCM-commissioning flag in secpolicy
+    ns.node_cmd(n1, "dataset commit active")
+
+def startRegistrar(ns):
+    logging.debug("starting OT Registrar")
+    ns.registrar_log_file = open("tmp/ot-registrar.log", 'w')
+    subprocess.Popen([
+        'java', '-jar', './etc/ot-registrar/ot-registrar.jar', '-registrar', '-vvv', '-f',
+        './etc/ot-registrar/credentials_registrar.p12', '-d', thread_domain_name
+    ],
+                                             stdout=ns.registrar_log_file,
+                                             stderr=subprocess.STDOUT)
+
+def verifyRegistrarStarted():
+    for n in range(1, 20):
+        time.sleep(0.5)
+        if os.path.isfile("tmp/ot-registrar.log"):
+            with open("tmp/ot-registrar.log", 'r') as file:
+                rlog = file.read()
+                if "Registrar listening (CoAPS)" in rlog:
+                    process_list = subprocess.run(["ps", "a"], capture_output=True, text=True).stdout
+                    if "ot-registrar.jar" in process_list:
+                        return True
+    return False
+
+def enrollBr(ns, nid):
+    ns.coaps()  # clear coaps
+
+    # BR enrolls via AIL.
+    ns.node_cmd(nid, "ipaddr add fd12::5")  # dummy address to allow sending to AIL. TODO resolve in stack.
+    ns.go(1)
+    ns.joiner_startccmbr(nid)
+    ns.go(5)
+
+    coap_events = ns.coaps()  # see emitted CoAP events
+    if len(coap_events) != 4:  # messages are /rv, /vs, /sen, /es
+        logging.error("BR may not have enrolled correctly.")
+        #raise Exception("BR may not have enrolled correctly.")
+
+def setupStartTopology(ns):
+    n1 = ns.add("br", version="ccm")
+    ns.go(1)
+    ns.speed = 3
+    enrollBr(ns, n1)
+    setActiveDataset(ns, n1)
+    ns.ifconfig_up(n1)
+    ns.thread_start(n1)
+    ns.go(10)
+
+    # n1 starts commissioner on BR
+    ns.commissioner_start(n1)
+    ns.go(5)
+    ns.commissioner_ccm_joiner_add(n1, "*")
+
+    # this changes default node type to 'CCM' node
+    ns.cmd('exe ftd "ot-cli-ftd_ccm"')
+    ns.cmd('exe mtd "ot-cli-mtd_ccm"')
+
+    # n2 added: not on network yet
+    n2 = ns.add("router")
+    ns.speed = 1
+    ns.autogo = True
+
+def main():
+    ns = setupNs()
+    if not verifyRegistrarStarted():
+        startRegistrar(ns)
+        if not verifyRegistrarStarted():
+            logging.error("Couldn't start OT-Registrar")
+            return
+    setupStartTopology(ns)
+    ns.interactive_cli()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except OTNSExitedError as ex:
+        if ex.exit_code != 0:
+            raise

--- a/pylibs/case_studies/ccm.yaml
+++ b/pylibs/case_studies/ccm.yaml
@@ -1,0 +1,25 @@
+#
+# Script for new CCM nodes to use for ccm.py
+#
+
+script:
+    ftd: |
+        joiner startccm
+
+    mtd: |
+        joiner startccm
+
+    br: |
+        routerselectionjitter 1
+        routerdowngradethreshold 33
+        routerupgradethreshold 33
+        netdata publish prefix fd00:f00d:cafe::/64 paros med
+        netdata publish route fc00::/7 s med
+        netdata publish route 64:ff9b::/96 sn med
+        bbr enable
+        srp server enable
+        br init 1 1
+        br enable
+
+    # This will ensure that the 'ftd' script is not run by the 'br'.
+    br-includes-ftd: false

--- a/pylibs/setup.py
+++ b/pylibs/setup.py
@@ -29,7 +29,7 @@ import setuptools
 
 setuptools.setup(
     name="pyOTNS",
-    version="2.1.0",
+    version="2.2.0",
     author="The OTNS Authors",
     description="Run OTNS2 OpenThread mesh network simulations from Python code",
     url="https://github.com/EskoDijk/ot-ns",

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -903,7 +903,7 @@ class BasicTests(OTNSTestCase):
             ns.add('sed')
             ns.go(30)
             self.assertFormPartitions(1)
-            for nid in range(1,8):
+            for nid in range(1, 8):
                 self.assertEqual('15', ns.node_cmd(nid, 'channel')[0])
 
     def testPhyStats(self):

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -903,6 +903,8 @@ class BasicTests(OTNSTestCase):
             ns.add('sed')
             ns.go(30)
             self.assertFormPartitions(1)
+            for nid in range(1,8):
+                self.assertEqual('15', ns.node_cmd(nid, 'channel')[0])
 
     def testPhyStats(self):
         self.tearDown()

--- a/pylibs/unittests/test_ccm_commissioning.py
+++ b/pylibs/unittests/test_ccm_commissioning.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import os
 import subprocess
 import time
 import unittest
@@ -93,6 +94,7 @@ class CcmTests(OTNSTestCase):
         if cls.registrar_process is not None:
             return
         logging.debug("starting OT Registrar")
+        os.makedirs("tmp", exist_ok=True)
         cls.registrar_log_file = open("tmp/ot-registrar.log", 'w')
         cls.registrar_process = subprocess.Popen([
             'java', '-jar', './etc/ot-registrar/ot-registrar.jar', '-registrar', '-vv', '-f',
@@ -113,11 +115,12 @@ class CcmTests(OTNSTestCase):
     def verifyRegistrarStarted(cls) -> None:
         for n in range(1, 20):
             time.sleep(0.5)
-            with open("tmp/ot-registrar.log", 'r') as file:
-                if "Registrar listening (CoAPS)" in file.read():
-                    with open("tmp/ot-masa.log", 'r') as file2:
-                        if "MASA server listening (HTTPS)" in file2.read():
-                            return
+            if os.path.isfile("tmp/ot-registrar.log"):
+                with open("tmp/ot-registrar.log", 'r') as file:
+                    if "Registrar listening (CoAPS)" in file.read():
+                        with open("tmp/ot-masa.log", 'r') as file2:
+                            if "MASA server listening (HTTPS)" in file2.read():
+                                return
         cls.stopRegistrar()
         raise Exception("OT-Registrar or OT-Masa not started correctly")
 

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -168,10 +168,11 @@ func DefaultNodeConfig() NodeConfig {
 
 func DefaultNodeScripts() *YamlScriptConfig {
 	return &YamlScriptConfig{
-		Mtd: strings.Join(defaultMtdInitScript, "\n"),
-		Ftd: strings.Join(defaultFtdInitScript, "\n"),
-		Br:  strings.Join(defaultBrScript, "\n"),
-		All: strings.Join(defaultAllInitScript, "\n"),
+		Mtd:           strings.Join(defaultMtdInitScript, "\n"),
+		Ftd:           strings.Join(defaultFtdInitScript, "\n"),
+		Br:            strings.Join(defaultBrScript, "\n"),
+		BrIncludesFtd: true,
+		All:           strings.Join(defaultAllInitScript, "\n"),
 	}
 }
 

--- a/simulation/nodescript_parser.go
+++ b/simulation/nodescript_parser.go
@@ -40,6 +40,7 @@ func ReadNodeScript(fn string) (*YamlScriptConfig, error) {
 		return nil, err
 	}
 	cfgFile := YamlConfigFile{}
+	cfgFile.ScriptConfig.BrIncludesFtd = true
 	err = yaml.Unmarshal(b, &cfgFile)
 	if err != nil {
 		err = fmt.Errorf("error in YAML file: %v", err)

--- a/simulation/sim_hosts.go
+++ b/simulation/sim_hosts.go
@@ -249,8 +249,6 @@ func (sh *SimHosts) handleUdpFromSimHost(simConn *SimConn, udpData []byte) {
 			},
 		}
 		sh.sim.Dispatcher().PostEventAsync(ev)
-		logger.Debugf("sh.sim.Dispatcher().PostEventAsync(ev) FIXME %v", ev)
-		logger.Debugf("simConn.Nat66State = %v", simConn.Nat66State)
 	}
 }
 

--- a/simulation/types.go
+++ b/simulation/types.go
@@ -83,10 +83,11 @@ type YamlConfigFile struct {
 
 // YamlScriptConfig defines startup scripts for nodes, depending on node type.
 type YamlScriptConfig struct {
-	Mtd string `yaml:"mtd"`
-	Ftd string `yaml:"ftd"`
-	Br  string `yaml:"br"`
-	All string `yaml:"all"`
+	Mtd           string `yaml:"mtd"`
+	Ftd           string `yaml:"ftd"`
+	Br            string `yaml:"br"`
+	BrIncludesFtd bool   `yaml:"br-includes-ftd"`
+	All           string `yaml:"all"`
 }
 
 // YamlNetworkConfig is a global network config that can be loaded/saved in YAML.
@@ -126,7 +127,11 @@ func (ys *YamlScriptConfig) BuildFtdScript() []string {
 }
 
 func (ys *YamlScriptConfig) BuildBrScript() []string {
-	script := ys.Ftd + "\n" + ys.Br + "\n" + ys.All
+	script := ""
+	if ys.BrIncludesFtd {
+		script = ys.Ftd + "\n"
+	}
+	script += ys.Br + "\n" + ys.All
 	return strings.Split(script, "\n")
 }
 


### PR DESCRIPTION
[pylibs][simulation][ccm] 
* Adding ccm.py case study where added nodes will automatically perform CCM-All onboarding. 
* Depends on a PR/branch of openthread-ccm; 
* Updated nodescript parser to allow separate FTD/BR configurations for scripts; 
* pylibs version bumped to 2.2.0