### PR TITLE
[all] Support for RCP+Host, with real-time UART via stdin/stdout, and simplify code

### DIFF
--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -625,9 +625,12 @@ func (rt *CmdRunner) executeNode(cc *CommandContext, cmd *NodeCmd) {
 
 		if cmd.Command != nil {
 			var output []string
+			var cmdHasDoneStringOutput bool
 
 			if cc.isBackgroundCmd {
-				output = node.CommandNoDone(*cmd.Command)
+				output, cmdHasDoneStringOutput = node.CommandNoDone(*cmd.Command)
+				// If the command did generate 'Done', then mark it again as a non-background command.
+				cc.isBackgroundCmd = !cmdHasDoneStringOutput
 			} else {
 				output = node.Command(*cmd.Command)
 			}
@@ -1123,7 +1126,7 @@ func (rt *CmdRunner) executeScan(cc *CommandContext, cmd *ScanCmd) {
 			cc.errorf("node %d not found", cmd.Node.Id)
 			return
 		}
-		output := node.CommandNoDone("scan")
+		output, _ := node.CommandNoDone("scan")
 		err := node.CommandResult()
 		cc.error(err)
 		if err == nil {

--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -359,7 +359,7 @@ func (rt *CmdRunner) executeGo(cc *CommandContext, cmd *GoCmd) {
 		})
 		cc.err = <-done // block for the simulation period.
 	} else {
-		for { // run forever but stop if rt.ctx.Err indicates "done"
+		for { // run forever but stop if an error occurs.
 			rt.postAsyncWait(cc, func(sim *simulation.Simulation) {
 				sim.SetSpeed(speed) // permanent speed update
 				done = sim.Go(time.Hour)

--- a/cli/CmdRunner.go
+++ b/cli/CmdRunner.go
@@ -359,7 +359,7 @@ func (rt *CmdRunner) executeGo(cc *CommandContext, cmd *GoCmd) {
 		})
 		cc.err = <-done // block for the simulation period.
 	} else {
-		for { // run forever but stop if an error occurs.
+		for { // run forever but stop if an error occurs or the context indicates "done".
 			rt.postAsyncWait(cc, func(sim *simulation.Simulation) {
 				sim.SetSpeed(speed) // permanent speed update
 				done = sim.Go(time.Hour)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -201,16 +201,23 @@ func TestContextlessCommandPat(t *testing.T) {
 func TestBackgroundCommandPat(t *testing.T) {
 	// only node-context commands are required to test here. See isBackgroundCommand() why.
 	assert.True(t, backgroundCommandsPat.MatchString("scan"))
+	assert.True(t, backgroundCommandsPat.MatchString("ping"))
 	assert.True(t, backgroundCommandsPat.MatchString("discover"))
 	assert.True(t, backgroundCommandsPat.MatchString("dns resolve 1234"))
 	assert.True(t, backgroundCommandsPat.MatchString("dns resolve4 1234"))
 	assert.True(t, backgroundCommandsPat.MatchString("dns browse example.com"))
 	assert.True(t, backgroundCommandsPat.MatchString("dns service test"))
 	assert.True(t, backgroundCommandsPat.MatchString("dns servicehost testlabel testname"))
-	assert.False(t, backgroundCommandsPat.MatchString("dns compression enable"))
+	assert.True(t, backgroundCommandsPat.MatchString("dns compression enable"))
 	assert.True(t, backgroundCommandsPat.MatchString("networkdiagnostic get ff02::1234 23 24 25"))
 	assert.True(t, backgroundCommandsPat.MatchString("networkdiagnostic reset fd18::1234 2 3"))
-	assert.False(t, backgroundCommandsPat.MatchString("networkdiagnostic qry ff02::1234 23 24 25"))
+	assert.True(t, backgroundCommandsPat.MatchString("networkdiagnostic qry ff02::1234 23 24 25"))
+	assert.True(t, backgroundCommandsPat.MatchString("mdns register anystring anystring"))
+	assert.True(t, backgroundCommandsPat.MatchString("mdns   register  anystring anystring"))
+
+	assert.False(t, backgroundCommandsPat.MatchString("state"))
+	assert.False(t, backgroundCommandsPat.MatchString("coap get ff02::1234 test"))
+	assert.True(t, backgroundCommandsPat.MatchString("mdns config anystring"))
 }
 
 type mockCliHandler struct {

--- a/cli/types.go
+++ b/cli/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2025, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,11 +29,27 @@ package cli
 import (
 	"regexp"
 	"sort"
+	"strings"
 )
 
 var (
+	backgroundCommands = []string{
+		"detach",
+		"discover",
+		"dns",
+		"linkmetrics",
+		`mdns\s+register`,
+		"meshdiag",
+		"mlr",
+		"networkdiagnostic",
+		"p2p",
+		"ping",
+		"scan",
+		"sntp",
+	}
+
+	backgroundCommandsPat  = regexp.MustCompile(`(` + strings.Join(backgroundCommands, "|") + `)\b`)
 	contextLessCommandsPat = regexp.MustCompile(`(exit|node|!.+)\b`)
-	backgroundCommandsPat  = regexp.MustCompile(`(discover|dns resolve|dns resolve4|dns browse|dns service|dns servicehost|scan|networkdiagnostic get|networkdiagnostic reset|meshdiag)\b`)
 )
 
 func isContextlessCommand(line string) bool {
@@ -42,6 +58,7 @@ func isContextlessCommand(line string) bool {
 
 func isBackgroundCommand(cmd *Command) bool {
 	if cmd.Node != nil && cmd.Node.Command != nil {
+		// check if the OT-node command is a potential background command (not guaranteed).
 		return backgroundCommandsPat.MatchString(*cmd.Node.Command)
 	}
 	if cmd.Scan != nil {

--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -129,7 +129,7 @@ func (node *Node) String() string {
 	return GetNodeName(node.Id)
 }
 
-// SendToVirtualUART sends any data to the virtual time UART of the node.
+// SendToVirtualUART sends any data to the virtual-time UART of the node.
 func (node *Node) SendToVirtualUART(data []byte) error {
 	var err error
 	evt := &Event{

--- a/dispatcher/Node.go
+++ b/dispatcher/Node.go
@@ -129,8 +129,8 @@ func (node *Node) String() string {
 	return GetNodeName(node.Id)
 }
 
-// SendToUART sends any data to virtual time UART of the node.
-func (node *Node) SendToUART(data []byte) error {
+// SendToVirtualUART sends any data to the virtual time UART of the node.
+func (node *Node) SendToVirtualUART(data []byte) error {
 	var err error
 	evt := &Event{
 		Timestamp: node.D.CurTime,
@@ -190,7 +190,7 @@ func (node *Node) sendEvent(evt *Event) {
 		reEvaluateTime, isUpdated := node.failureCtrl.OnTimeAdvanced(oldTime)
 		if isUpdated {
 			wakeEvt := &Event{
-				Type:      EventTypeAlarmFired,
+				Type:      EventTypeScheduleNode,
 				NodeId:    node.Id,
 				Timestamp: reEvaluateTime,
 			}
@@ -243,10 +243,6 @@ func (node *Node) Recover() {
 		node.D.vis.OnNodeRecover(node.Id)
 		node.logger.Debugf("radio recovered from scheduled failure")
 	}
-}
-
-func (node *Node) DumpStat() string {
-	return fmt.Sprintf("CurTime=%v, Failed=%-5v, RecoverTS=%v", node.CurTime, node.isFailed, node.failureCtrl.recoverTs)
 }
 
 func (node *Node) SetFailTime(failTime FailTime) {

--- a/dispatcher/alarm_mgr.go
+++ b/dispatcher/alarm_mgr.go
@@ -42,6 +42,10 @@ type alarmEvent struct {
 
 type alarmQueue []*alarmEvent
 
+var (
+	ts uint64 = 0
+)
+
 func (aq alarmQueue) Len() int {
 	return len(aq)
 }
@@ -105,6 +109,10 @@ func (am *alarmMgr) SetNotified(nodeid NodeId) {
 }
 
 func (am *alarmMgr) SetTimestamp(nodeid int, timestamp uint64) {
+	if timestamp < ts {
+		logger.Panicf("Set ts %v smaller than current ts %v", timestamp, ts)
+	}
+
 	e := am.events[nodeid]
 	logger.AssertNotNil(e)
 
@@ -112,6 +120,13 @@ func (am *alarmMgr) SetTimestamp(nodeid int, timestamp uint64) {
 		e.Timestamp = timestamp
 		heap.Fix(&am.q, e.index)
 	}
+}
+
+func (am *alarmMgr) SetTs(timestamp uint64) {
+	if timestamp > am.NextTimestamp() {
+		logger.Panicf("Set ts %v larger than next ts %v", timestamp, am.NextTimestamp())
+	}
+	ts = timestamp
 }
 
 func (am *alarmMgr) GetTimestamp(nodeid int) uint64 {

--- a/dispatcher/alarm_mgr.go
+++ b/dispatcher/alarm_mgr.go
@@ -42,10 +42,6 @@ type alarmEvent struct {
 
 type alarmQueue []*alarmEvent
 
-var (
-	ts uint64 = 0
-)
-
 func (aq alarmQueue) Len() int {
 	return len(aq)
 }
@@ -109,10 +105,6 @@ func (am *alarmMgr) SetNotified(nodeid NodeId) {
 }
 
 func (am *alarmMgr) SetTimestamp(nodeid int, timestamp uint64) {
-	if timestamp < ts {
-		logger.Panicf("Set ts %v smaller than current ts %v", timestamp, ts)
-	}
-
 	e := am.events[nodeid]
 	logger.AssertNotNil(e)
 
@@ -120,13 +112,6 @@ func (am *alarmMgr) SetTimestamp(nodeid int, timestamp uint64) {
 		e.Timestamp = timestamp
 		heap.Fix(&am.q, e.index)
 	}
-}
-
-func (am *alarmMgr) SetTs(timestamp uint64) {
-	if timestamp > am.NextTimestamp() {
-		logger.Panicf("Set ts %v larger than next ts %v", timestamp, am.NextTimestamp())
-	}
-	ts = timestamp
 }
 
 func (am *alarmMgr) GetTimestamp(nodeid int) uint64 {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -58,7 +58,7 @@ type CallbackHandler interface {
 	// OnUartWrite Notifies that the node's UART was written with data.
 	OnUartWrite(nodeid NodeId, data []byte)
 
-	// OnLogWrite Notifies that a log item wsa written to the node's log.
+	// OnLogWrite Notifies that a log item was written to the node's log.
 	OnLogWrite(nodeid NodeId, data []byte)
 
 	// OnNextEventTime Notifies that the Dispatcher simulated-time will move to the next event time.
@@ -76,7 +76,7 @@ type goDuration struct {
 	duration time.Duration
 	done     chan error // signals end of the simulation duration and success (nil) or some error.
 	speed    float64    // a speedup value, or DefaultDispatcherSpeed.
-	cancel   bool       // if set to true, the simulation duration will be cancelled early.
+	cancel   bool       // if set to true, the simulation duration will be canceled early.
 }
 
 type Dispatcher struct {
@@ -289,27 +289,23 @@ func (d *Dispatcher) Run() {
 loop:
 	for {
 		select {
-		case t := <-d.taskChan:
-			t()
-		case duration := <-d.goDurationChan:
-			d.currentGoDuration = duration
-			if len(d.nodes) == 0 || duration.duration < 0 {
-				// no nodes or no sim progress, sleep for a small duration to avoid high cpu
-				d.RecvEvents()
-				time.Sleep(time.Millisecond * 10)
-			} else {
-				logger.AssertTrue(d.CurTime == d.pauseTime)
-				d.goSimulateForDuration(duration)
-				logger.AssertTrue(d.CurTime == d.pauseTime)
-
-				d.syncAllNodes()
-				if d.pcap != nil {
-					_ = d.pcap.Sync()
-				}
-			}
-			close(duration.done)
 		case <-done:
 			break loop
+		case t := <-d.taskChan:
+			t()
+		case ev := <-d.eventChan:
+			d.handleRecvEvent(ev)
+		case duration := <-d.goDurationChan:
+			d.currentGoDuration = duration
+			logger.AssertTrue(d.CurTime == d.pauseTime)
+			d.goSimulateForDuration(duration)
+			logger.AssertTrue(d.CurTime == d.pauseTime)
+
+			d.syncAllNodes()
+			if d.pcap != nil {
+				_ = d.pcap.Sync()
+			}
+			close(duration.done)
 		}
 	}
 
@@ -360,7 +356,7 @@ func (d *Dispatcher) goSimulateForDuration(duration goDuration) {
 		d.syncAliveNodes() // normally there should not be any alive nodes anymore.
 
 		if len(d.aliveNodes) == 0 {
-			// all are asleep now - process the next Events in queue, either alarm or other type, for a single time.
+			// all are asleep now - process the next Events in queue, for a single simulated time value.
 			goon := d.processNextEvent(d.speed)
 			logger.AssertTrue(d.CurTime <= d.pauseTime)
 
@@ -376,14 +372,14 @@ func (d *Dispatcher) goSimulateForDuration(duration goDuration) {
 	if duration.speed != DefaultDispatcherSpeed { // restore original speed after period with custom speed set.
 		d.SetSpeed(postSpeed)
 	}
-	if d.pauseTime > d.CurTime { // if we e.g. cancelled period simulation early, and pauseTime not reached.
+	if d.pauseTime > d.CurTime { // if we e.g. canceled simulation period early, and pauseTime is not reached.
 		d.pauseTime = d.CurTime
 	}
 }
 
 // handleRecvEvent is the central handler for all events externally received from nodes/entities.
 // It may only process events immediately that are to be executed at time d.CurTime. Future events
-// will need to be queued (scheduled).
+// are queued (scheduled).
 func (d *Dispatcher) handleRecvEvent(evt *Event) {
 	nodeid := evt.NodeId
 	node := d.nodes[nodeid]
@@ -397,19 +393,19 @@ func (d *Dispatcher) handleRecvEvent(evt *Event) {
 	}
 	evt.Timestamp = d.CurTime // timestamp the incoming event
 
-	// TODO document this use (for alarm messages)
-	delay := evt.Delay
-	if delay >= 2147483647 {
-		delay = Ever
-	}
-
 	switch evt.Type {
 	case EventTypeAlarmFired:
 		d.Counters.AlarmEvents += 1
 		if evt.MsgId == node.msgId { // if OT-node has seen my last sent event (so it is done processing)
 			d.setSleeping(node.Id)
 		}
+		delay := evt.Delay
+		if delay >= 2147483647 { // if OT Alarm delay is INT32_MAX ("infinity"), convert to "Ever".
+			delay = Ever
+		}
 		d.alarmMgr.SetTimestamp(nodeid, d.CurTime+delay) // schedule future wake-up of node
+	case EventTypeScheduleNode:
+		logger.Panicf("EventTypeScheduleNode (%v) not expected from OT node", evt.Type)
 	case EventTypeRadioCommStart,
 		EventTypeRadioState,
 		EventTypeRadioChannelSample:
@@ -430,6 +426,7 @@ func (d *Dispatcher) handleRecvEvent(evt *Event) {
 		node.onStatusPushExtAddr(extaddr)
 	case EventTypeNodeInfo:
 		d.Counters.OtherEvents += 1
+		// No further handling is needed; the node info was already used at this point.
 	case EventTypeNodeDisconnected:
 		d.Counters.OtherEvents += 1
 		logger.Debugf("%s socket disconnected.", node)
@@ -438,7 +435,7 @@ func (d *Dispatcher) handleRecvEvent(evt *Event) {
 	case EventTypeUdpToHost,
 		EventTypeIp6ToHost:
 		d.Counters.HostEvents += 1
-		d.sendMsgToHost(node, evt)
+		d.onMsgToHost(node, evt)
 		d.cbHandler.OnMsgToHost(node.Id, evt)
 	case EventTypeUdpFromHost,
 		EventTypeIp6FromHost:
@@ -464,17 +461,17 @@ loop:
 		shouldBlock := len(d.aliveNodes) > 0
 		if shouldBlock {
 			select {
-			case evt := <-d.eventChan: // get new event
+			case evt := <-d.eventChan: // get new event from (any) node
 				count += 1
 				d.handleRecvEvent(evt)
 			case <-blockTimeout: // timeout
 				break loop
 			case <-done:
 				if !isExiting {
-					blockTimeout = time.After(time.Millisecond * 250)
+					blockTimeout = time.After(time.Millisecond * 250) // shorten timeout when exiting
 					isExiting = true
 				}
-				time.Sleep(time.Millisecond * 10)
+				time.Sleep(time.Millisecond * 10) // avoid high CPU usage
 				break
 			}
 		} else {
@@ -566,7 +563,7 @@ func (d *Dispatcher) processNextEvent(simSpeed float64) bool {
 				// execute event - either a msg to be dispatched, or handled internally.
 				if !evt.MustDispatch {
 					switch evt.Type {
-					case EventTypeAlarmFired:
+					case EventTypeScheduleNode:
 						d.advanceNodeTime(node, evt.Timestamp, false)
 					case EventTypeRadioLog:
 						node.logger.Tracef("%s", string(evt.Data))
@@ -590,7 +587,7 @@ func (d *Dispatcher) processNextEvent(simSpeed float64) bool {
 						d.sendRadioCommRxDoneEvents(node, evt)
 					case EventTypeUdpFromHost,
 						EventTypeIp6FromHost:
-						node.sendEvent(evt) // TODO no loss on external network is simulated currently.
+						node.sendEvent(evt) // TODO no packet-loss on external network is simulated currently.
 					default:
 						if d.radioModel.OnEventDispatch(node.RadioNode, node.RadioNode, evt) {
 							node.sendEvent(evt)
@@ -866,18 +863,18 @@ func (d *Dispatcher) sendOneRadioFrame(evt *Event, srcnode *Node, dstnode *Node)
 	}
 }
 
-func (d *Dispatcher) sendMsgToHost(node *Node, evt *Event) {
-	if d.cfg.PcapEnabled {
-		/** TODO write IPv6 packet to a separate pcap file
-		d.pcapFrameChan <- pcap.Frame{
-			Timestamp: evt.Timestamp,
-			Data:      evt.Data,
-			Channel:   0,
-			Rssi:      RssiInvalid,
-		}
-		*/
-		node.logger.Debugf("sendMsgToHost: %v", evt)
+func (d *Dispatcher) onMsgToHost(node *Node, evt *Event) {
+	//if d.cfg.PcapEnabled {
+	/** TODO write IPv6 packet to a separate pcap file
+	d.pcapFrameChan <- pcap.Frame{
+		Timestamp: evt.Timestamp,
+		Data:      evt.Data,
+		Channel:   0,
+		Rssi:      RssiInvalid,
 	}
+	*/
+	//}
+	node.logger.Debugf("onMsgToHost: %v", evt)
 }
 
 func (d *Dispatcher) setAlive(nodeid NodeId) {
@@ -1372,12 +1369,21 @@ func (d *Dispatcher) SetVisualizationOptions(opts VisualizationOptions) {
 	d.visOptions = opts
 }
 
-func (d *Dispatcher) NotifyCommand(nodeid NodeId) {
-	d.setAlive(nodeid)
+// NotifyCommand notifies the Dispatcher that the node is now processing a command which was
+// delivered to the node with other means than Event(s), such as writing to the realtime UART
+// of the node or sending a signal to the node's process.
+func (d *Dispatcher) NotifyCommand(nodeid NodeId, isNodeProcessEnding bool) {
+	node := d.nodes[nodeid]
+	if node != nil {
+		d.setAlive(nodeid)
+		if !isNodeProcessEnding {
+			d.advanceNodeTime(node, d.CurTime, false)
+		}
+	}
 }
 
-// NotifyNodeFailure is called by other goroutines to notify the dispatcher that a node process has
-// failed. From failed nodes, we don't expect further messages and they can't be alive.
+// NotifyNodeProcessFailure notifies the dispatcher that a node process has failed.
+// From failed nodes, we don't expect further messages and they can't be alive.
 func (d *Dispatcher) NotifyNodeProcessFailure(nodeid NodeId) {
 	d.eventChan <- &Event{
 		Delay:  0,
@@ -1505,7 +1511,7 @@ func (d *Dispatcher) handleRadioState(node *Node, evt *Event) {
 	// This is independent from any alarm-time set by the node which is the OT's stack next-operation time.
 	if evt.Delay > 0 {
 		d.eventQueue.Add(&Event{
-			Type:      EventTypeAlarmFired,
+			Type:      EventTypeScheduleNode,
 			NodeId:    node.Id,
 			Timestamp: d.CurTime + evt.Delay,
 		})

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -496,7 +496,14 @@ func (d *Dispatcher) processNextEvent(simSpeed float64) bool {
 	// fetch time of next event
 	nextAlarmTime := d.alarmMgr.NextTimestamp()
 	nextSendTime := d.eventQueue.NextTimestamp()
-	logger.AssertTrue(nextSendTime >= d.CurTime && nextAlarmTime >= d.CurTime)
+	if nextSendTime < d.CurTime {
+		logger.Errorf("Eventqueue: d.CurTime=%v, nextSendTime=%v, q:", d.CurTime, nextSendTime)
+		for _, evt := range d.eventQueue.q {
+			logger.Errorf("  %v", evt)
+		}
+	}
+	logger.AssertTrue(nextSendTime >= d.CurTime)
+	logger.AssertTrue(nextAlarmTime >= d.CurTime)
 
 	nextEventTime := min(nextAlarmTime, nextSendTime)
 
@@ -594,7 +601,7 @@ func (d *Dispatcher) processNextEvent(simSpeed float64) bool {
 						}
 					}
 				}
-			} else if evt.NodeId > 0 {
+			} else if evt.Type != EventTypeNoOperation && evt.NodeId > 0 {
 				logger.Warnf("processNextEvent() with deleted/unknown node %v: %v", evt.NodeId, evt)
 			}
 		}
@@ -603,7 +610,7 @@ func (d *Dispatcher) processNextEvent(simSpeed float64) bool {
 		nextEventTime = min(nextAlarmTime, nextSendTime)
 	}
 
-	return len(d.nodes) > 0
+	return nextEventTime <= d.pauseTime || len(d.nodes) > 0
 }
 
 func (d *Dispatcher) eventsReader() {
@@ -1156,6 +1163,7 @@ func (d *Dispatcher) visSend(srcid NodeId, dstid NodeId, visInfo *visualize.MsgV
 func (d *Dispatcher) advanceTime(ts uint64) {
 	logger.AssertTrue(d.CurTime <= ts, "%v > %v", d.CurTime, ts)
 	d.CurTime = ts
+	d.eventQueue.SetTimestamp(ts)
 
 	elapsedTime := int64(d.CurTime - d.speedStartTime)
 	elapsedRealTime := time.Since(d.speedStartRealTime) / time.Microsecond

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -471,7 +471,7 @@ loop:
 					blockTimeout = time.After(time.Millisecond * 250) // shorten timeout when exiting
 					isExiting = true
 				}
-				time.Sleep(time.Millisecond * 10) // avoid high CPU usage
+				time.Sleep(time.Millisecond * 10) // avoid high CPU usage while we stay in the for loop
 				break
 			}
 		} else {
@@ -594,7 +594,7 @@ func (d *Dispatcher) processNextEvent(simSpeed float64) bool {
 						}
 					}
 				}
-			} else if evt.Type != EventTypeNoOperation && evt.NodeId != InvalidNodeId {
+			} else if evt.Type != EventTypeNoOperation {
 				logger.Warnf("processNextEvent() with deleted/unknown node %v: %v", evt.NodeId, evt)
 			}
 		}

--- a/dispatcher/send_queue.go
+++ b/dispatcher/send_queue.go
@@ -30,23 +30,11 @@ import (
 	"container/heap"
 
 	. "github.com/openthread/ot-ns/event"
-	"github.com/openthread/ot-ns/logger"
 	. "github.com/openthread/ot-ns/types"
 )
 
 type sendQueue struct {
-	q  []*Event
-	ts uint64
-}
-
-func (sq *sendQueue) SetTimestamp(ts uint64) {
-	if ts > sq.ts {
-		logger.Tracef("Ts  %v", ts)
-		if sq.NextTimestamp() < sq.ts {
-			logger.Panicf("Advance time to %v with next event %v", ts, sq.NextTimestamp())
-		}
-	}
-	sq.ts = ts
+	q []*Event
 }
 
 func (sq *sendQueue) Len() int {
@@ -94,10 +82,6 @@ func (sq *sendQueue) NextEvent() *Event {
 }
 
 func (sq *sendQueue) Add(evt *Event) {
-	logger.Tracef("Add %v\t\t%v", evt.Timestamp, evt)
-	if evt.Timestamp < sq.ts {
-		logger.Panicf("Add event with timestamp %v before next event %v", evt.Timestamp, sq.ts)
-	}
 	heap.Push(sq, evt)
 }
 

--- a/dispatcher/send_queue.go
+++ b/dispatcher/send_queue.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The OTNS Authors.
+// Copyright (c) 2020-2026, The OTNS Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -91,7 +91,6 @@ func (sq *sendQueue) DisableEventsForNode(nodeid NodeId) {
 	for _, evt := range sq.q {
 		if evt.NodeId == nodeid {
 			evt.Type = EventTypeNoOperation // make the event do nothing.
-			evt.NodeId = InvalidNodeId
 		}
 	}
 }

--- a/event/event.go
+++ b/event/event.go
@@ -43,7 +43,7 @@ type EventType = uint8
 const (
 	// Event type IDs (external, shared between OT-NS and OT node)
 	EventTypeAlarmFired         EventType = 0
-	EventTypeRadioReceived      EventType = 1
+	EventTypeScheduleNode       EventType = 1
 	EventTypeUartWrite          EventType = 2
 	EventTypeRadioSpinelWrite   EventType = 3
 	EventTypePostCmd            EventType = 4

--- a/event/event.go
+++ b/event/event.go
@@ -65,6 +65,7 @@ const (
 	EventTypeIp6ToHost          EventType = 21
 	EventTypeUdpFromHost        EventType = 22
 	EventTypeIp6FromHost        EventType = 23
+	EventTypeNoOperation        EventType = 255
 )
 
 const (
@@ -316,17 +317,6 @@ func (e *Event) String() string {
 	if len(e.Data) > 0 {
 		paylStr = fmt.Sprintf(",payl=%s", hex.EncodeToString(e.Data))
 	}
-	s := fmt.Sprintf("Ev{%2d,nid=%d,mid=%d,dly=%v%s}", e.Type, e.NodeId, e.MsgId, e.Delay, paylStr)
+	s := fmt.Sprintf("Ev{%2d,ts=%d,nid=%d,mid=%d,dly=%v%s}", e.Type, e.Timestamp, e.NodeId, e.MsgId, e.Delay, paylStr)
 	return s
 }
-
-/*
-func keepPrintableChars(s string) string {
-	return strings.Map(func(r rune) rune {
-		if unicode.IsPrint(r) {
-			return r
-		}
-		return -1
-	}, s)
-}
-*/

--- a/logger/nodelogger.go
+++ b/logger/nodelogger.go
@@ -158,7 +158,7 @@ func (nl *NodeLogger) IsLevelVisible(level Level) bool {
 }
 
 // LogOt logs a complete OT format log string, which includes timestamp, log level character, and
-// the log message. The right level to log is automatically determined.
+// the log message. The right log level is automatically determined.
 func (nl *NodeLogger) LogOt(levelAndMsg string) {
 	isOtLogLine, level := ParseOtLogLine(levelAndMsg)
 	levelAndMsg = strings.TrimSpace(levelAndMsg)

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -1076,6 +1076,23 @@ class BasicTests(OTNSTestCase):
         with self.assertRaises(errors.OTNSCliError):
             ns.node_cmd(nid_diag, f'abcdefgdns xquery test.example')
 
+    def testNodeReset(self):
+        ns: OTNS = self.ns
+
+        ns.add('router')
+        ns.add('router')
+        ns.go(20)
+        self.assertFormPartitions(1)
+
+        ns.node_cmd(1, 'reset')
+        ns.go(20)
+        self.assertFormPartitions(1)
+
+        # TODO: find out why settings are not cleared?
+        ns.node_cmd(1, 'factoryreset')
+        ns.go(20)
+        self.assertFormPartitions(1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylibs/unittests/test_basic.py
+++ b/pylibs/unittests/test_basic.py
@@ -1076,23 +1076,6 @@ class BasicTests(OTNSTestCase):
         with self.assertRaises(errors.OTNSCliError):
             ns.node_cmd(nid_diag, f'abcdefgdns xquery test.example')
 
-    def testNodeReset(self):
-        ns: OTNS = self.ns
-
-        ns.add('router')
-        ns.add('router')
-        ns.go(20)
-        self.assertFormPartitions(1)
-
-        ns.node_cmd(1, 'reset')
-        ns.go(20)
-        self.assertFormPartitions(1)
-
-        # TODO: find out why settings are not cleared?
-        ns.node_cmd(1, 'factoryreset')
-        ns.go(20)
-        self.assertFormPartitions(1)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/radiomodel/radiomodel.go
+++ b/radiomodel/radiomodel.go
@@ -79,7 +79,7 @@ type RadioModel interface {
 	OnEventDispatch(srcNode *RadioNode, dstNode *RadioNode, evt *Event) bool
 
 	// OnNextEventTime is called when the Dispatcher moves the simulation time to a higher timestamp ts,
-	// where new event(s) will be executed.
+	// and all event(s) for previous times have already been executed.
 	OnNextEventTime(ts uint64)
 
 	// HandleEvent handles all radio-model events coming out of the simulator event queue.

--- a/simulation/node.go
+++ b/simulation/node.go
@@ -270,19 +270,22 @@ func (node *Node) inputCommand(cmd string) error {
 	return err
 }
 
-// CommandNoDone executes the command without expecting 'Done' (e.g. it's a background command).
-// It just reads output lines until the node is asleep.
-func (node *Node) CommandNoDone(cmd string) []string {
+// CommandNoDone executes the command without necessarily expecting 'Done' (e.g. it's a background command).
+// It just reads output lines until the node is asleep. If nevertheless 'Done' is received,
+// it returns the flag hasDoneOutput = true.
+func (node *Node) CommandNoDone(cmd string) ([]string, bool) {
+	hasDoneOutput := false
+
 	err := node.inputCommand(cmd)
 	if err != nil {
 		node.error(err)
-		return []string{}
+		return []string{}, false
 	}
 
 	_, err = node.expectLine(cmd, DefaultCommandTimeout)
 	if err != nil {
 		node.error(err)
-		return []string{}
+		return []string{}, false
 	}
 
 	var output []string
@@ -293,11 +296,15 @@ func (node *Node) CommandNoDone(cmd string) []string {
 		}
 		if strings.HasPrefix(line, "Error") {
 			node.error(errors.New(line))
+		} else if strings.TrimSpace(line) == "Done" {
+			// potential background commands that return a 'Done' CLI output at the end are flagged here.
+			hasDoneOutput = true
 		} else {
 			output = append(output, line)
+			hasDoneOutput = false
 		}
 	}
-	return output
+	return output, hasDoneOutput
 }
 
 // Command executes the command and waits for 'Done', or an 'Error', at end of output.

--- a/simulation/node_config.go
+++ b/simulation/node_config.go
@@ -155,6 +155,7 @@ func DefaultNodeConfig() NodeConfig {
 		IsRaw:          false,
 		IsRouter:       true,
 		IsMtd:          false,
+		IsRcp:          false,
 		IsBorderRouter: false,
 		RxOffWhenIdle:  false,
 		NodeLogFile:    true,

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -49,35 +49,37 @@ type Simulation struct {
 	Started chan struct{}
 	Exited  chan struct{}
 
-	ctx            *progctx.ProgCtx
-	stopped        bool
-	cfg            *Config
-	nodes          map[NodeId]*Node
-	d              *dispatcher.Dispatcher
-	vis            visualize.Visualizer
-	cmdRunner      CmdRunner
-	autoGo         bool
-	autoGoChange   chan bool
-	networkInfo    visualize.NetworkInfo
-	energyAnalyser *energy.EnergyAnalyser
-	nodePlacer     *NodeAutoPlacer
-	kpiMgr         *KpiManager
-	simHosts       *SimHosts
+	ctx              *progctx.ProgCtx
+	stopped          bool
+	cfg              *Config
+	nodes            map[NodeId]*Node
+	d                *dispatcher.Dispatcher
+	vis              visualize.Visualizer
+	cmdRunner        CmdRunner
+	autoGo           bool
+	autoGoChange     chan bool
+	isFirstNodeAdded bool
+	networkInfo      visualize.NetworkInfo
+	energyAnalyser   *energy.EnergyAnalyser
+	nodePlacer       *NodeAutoPlacer
+	kpiMgr           *KpiManager
+	simHosts         *SimHosts
 }
 
 func NewSimulation(ctx *progctx.ProgCtx, cfg *Config, dispatcherCfg *dispatcher.Config) (*Simulation, error) {
 	s := &Simulation{
-		Started:      make(chan struct{}),
-		Exited:       make(chan struct{}),
-		ctx:          ctx,
-		cfg:          cfg,
-		nodes:        map[NodeId]*Node{},
-		autoGo:       cfg.AutoGo || cfg.Realtime,
-		autoGoChange: make(chan bool, 1),
-		networkInfo:  visualize.DefaultNetworkInfo(),
-		nodePlacer:   NewNodeAutoPlacer(),
-		kpiMgr:       NewKpiManager(),
-		simHosts:     NewSimHosts(),
+		Started:          make(chan struct{}),
+		Exited:           make(chan struct{}),
+		ctx:              ctx,
+		cfg:              cfg,
+		nodes:            map[NodeId]*Node{},
+		autoGo:           cfg.AutoGo || cfg.Realtime,
+		autoGoChange:     make(chan bool, 1),
+		isFirstNodeAdded: false,
+		networkInfo:      visualize.DefaultNetworkInfo(),
+		nodePlacer:       NewNodeAutoPlacer(),
+		kpiMgr:           NewKpiManager(),
+		simHosts:         NewSimHosts(),
 	}
 	s.SetLogLevel(cfg.LogLevel)
 	s.networkInfo.Real = cfg.Realtime
@@ -157,9 +159,8 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 	s.nodes[nodeid] = node
 
 	// init of the sim/dispatcher nodes
-	node.uartType = nodeUartTypeVirtualTime
 	logger.AssertTrue(s.d.IsAlive(nodeid))
-	evtCnt := s.d.RecvEvents() // allow new node to connect, and to receive its startup events.
+	evtCnt := s.waitForSimulation(false) // allow new node to connect, and to receive its startup events.
 
 	if s.IsStopping() { // stop early when exiting the simulation.
 		err = CommandInterruptedError
@@ -218,6 +219,13 @@ func (s *Simulation) AddNode(cfg *NodeConfig) (*Node, error) {
 	node.DisplayPendingLogEntries()
 	node.DisplayPendingLines()
 
+	if err == nil {
+		if s.autoGo && !s.isFirstNodeAdded {
+			s.autoGoChange <- true // enable autogo after first node successfully added.
+		}
+		s.isFirstNodeAdded = true
+	}
+
 	return node, err
 }
 
@@ -231,10 +239,6 @@ func (s *Simulation) genNodeId() NodeId {
 
 func (s *Simulation) Run() {
 	defer logger.Debugf("simulation exit.")
-
-	if s.autoGo {
-		s.autoGoChange <- true
-	}
 
 	// run dispatcher in current thread, until exit.
 	s.ctx.WaitAdd("dispatcher", 1)
@@ -289,17 +293,19 @@ func (s *Simulation) SetAutoGo(isAuto bool) {
 func (s *Simulation) AutoGoRoutine(ctx *progctx.ProgCtx, sim *Simulation) {
 	defer ctx.WaitDone("autogo")
 
+	done := ctx.Done()
+
 	for {
 	loop2:
 		// First for block waits until autogo is enabled.
 		for {
 			select {
+			case <-done:
+				return
 			case isAutoGo := <-sim.autoGoChange:
 				if isAutoGo {
 					break loop2
 				}
-			case <-ctx.Done():
-				return
 			}
 		}
 
@@ -307,12 +313,12 @@ func (s *Simulation) AutoGoRoutine(ctx *progctx.ProgCtx, sim *Simulation) {
 		// Second for block executes Go() until autogo is disabled.
 		for {
 			select {
+			case <-done:
+				return
 			case isAutoGo := <-sim.autoGoChange:
 				if !isAutoGo {
 					break loop
 				}
-			case <-ctx.Done():
-				return
 			default:
 				<-sim.Go(time.Second)
 			}
@@ -362,18 +368,16 @@ func (s *Simulation) SetVisualizer(vis visualize.Visualizer) {
 	s.vis.SetNetworkInfo(s.GetNetworkInfo())
 }
 
-// OnUartWrite notifies the simulation that a node has received some data from UART.
-// It is part of implementation of dispatcher.CallbackHandler.
+// OnUartWrite implements the dispatcher.CallbackHandler interface.
 func (s *Simulation) OnUartWrite(nodeid NodeId, data []byte) {
 	node := s.nodes[nodeid]
 	if node == nil {
 		return
 	}
-	node.uartReader <- data
+	node.processUartData(data)
 }
 
-// OnLogWrite notifies the simulation that a node has generated a new log line/item.
-// It is part of implementation of dispatcher.CallbackHandler.
+// OnLogWrite implements the dispatcher.CallbackHandler interface.
 func (s *Simulation) OnLogWrite(nodeid NodeId, data []byte) {
 	node := s.nodes[nodeid]
 	if node == nil {
@@ -382,15 +386,16 @@ func (s *Simulation) OnLogWrite(nodeid NodeId, data []byte) {
 	node.Logger.LogOt(string(data))
 }
 
+// OnNextEventTime implements the dispatcher.CallbackHandler interface.
 func (s *Simulation) OnNextEventTime(nextTs uint64) {
 	// display the pending log messages of nodes. Nodes are sorted by id.
 	s.VisitNodesInOrder(func(node *Node) {
-		node.processUartData()
 		node.DisplayPendingLogEntries()
 		node.DisplayPendingLines()
 	})
 }
 
+// OnRfSimEvent implements the dispatcher.CallbackHandler interface.
 func (s *Simulation) OnRfSimEvent(nodeid NodeId, evt *event.Event) {
 	node := s.nodes[nodeid]
 	if node == nil {
@@ -401,10 +406,12 @@ func (s *Simulation) OnRfSimEvent(nodeid NodeId, evt *event.Event) {
 	case event.EventTypeRadioRfSimParamRsp:
 		node.pendingEvents <- evt
 	default:
+		// ignore any other event types.
 		break
 	}
 }
 
+// OnMsgToHost implements the dispatcher.CallbackHandler interface.
 func (s *Simulation) OnMsgToHost(nodeid NodeId, evt *event.Event) {
 	node := s.nodes[nodeid]
 	if node == nil {
@@ -475,9 +482,9 @@ func (s *Simulation) DeleteNode(nodeid NodeId) error {
 		err := fmt.Errorf("node %d not found", nodeid)
 		return err
 	}
-	s.d.NotifyCommand(nodeid) // sets node alive: we expect a NodeExit event to come as final one in queue.
+	s.d.NotifyCommand(nodeid, true) // sets node alive: we expect a NodeExit event as final one in queue.
 	_ = node.exit()
-	s.d.RecvEvents()
+	s.waitForSimulation(false)
 	s.d.DeleteNode(nodeid)
 	s.kpiMgr.stopNode(nodeid)
 	delete(s.nodes, nodeid)
@@ -517,6 +524,17 @@ func (s *Simulation) GoAtSpeed(duration time.Duration, speed float64) <-chan err
 	logger.AssertTrue(speed > 0)
 	s.d.GoCancel()
 	return s.d.GoAtSpeed(duration, speed)
+}
+
+// waitForSimulation is called to wait for the simulation to progress, receiving and handling events as
+// needed until all nodes are asleep. It returns the total number of new events received from nodes.
+func (s *Simulation) waitForSimulation(isBusyWaiting bool) int {
+	eventCount := s.Dispatcher().RecvEvents()
+	if isBusyWaiting && eventCount == 0 {
+		// avoid busy-loop when this method is repeatedly called, waiting for more events.
+		time.Sleep(10 * time.Millisecond)
+	}
+	return eventCount
 }
 
 func (s *Simulation) cleanTmpDir(simulationId int) error {

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -528,10 +528,10 @@ func (s *Simulation) GoAtSpeed(duration time.Duration, speed float64) <-chan err
 
 // waitForSimulation is called to wait for the simulation to progress, receiving and handling events as
 // needed until all nodes are asleep. It returns the total number of new events received from nodes.
+// isBusyWaiting must be only true if the caller repeatedly calls this method, waiting for new events.
 func (s *Simulation) waitForSimulation(isBusyWaiting bool) int {
 	eventCount := s.Dispatcher().RecvEvents()
 	if isBusyWaiting && eventCount == 0 {
-		// avoid busy-loop when this method is repeatedly called, waiting for more events.
 		time.Sleep(10 * time.Millisecond)
 	}
 	return eventCount

--- a/types/node_config.go
+++ b/types/node_config.go
@@ -36,6 +36,7 @@ type NodeConfig struct {
 	IsAutoPlaced   bool
 	IsRaw          bool // A raw node skips all initialization CLI commands, including any init-script.
 	IsMtd          bool
+	IsRcp          bool // An RCP node runs in real-time and is driven by a (non-simulated) host process.
 	IsRouter       bool
 	IsBorderRouter bool
 	RxOffWhenIdle  bool


### PR DESCRIPTION
This provides the basis for RCP+Host node support, where simulation RCP nodes are driven by a Host process that runs real-time and communicates (UART) via stdin/stdout with OTNS. A Dispatcher lineReader goroutine is added to receive UART bytes and OT log lines. All functions in the 'simulation' package that need Dispatcher communication or block on events reading are now simplified, to reduce developer's confusion.

Also, unused methods (mostly in simulation/node.go) are removed to reduce developer's confusion.